### PR TITLE
Forced references in the PatronCommandHandler unit tests to refer to …

### DIFF
--- a/src/Vigil.Domain/Messaging/ICommand.cs
+++ b/src/Vigil.Domain/Messaging/ICommand.cs
@@ -2,10 +2,7 @@
 
 namespace Vigil.Domain.Messaging
 {
-    public interface ICommand
+    public interface ICommand : IKeyIdentity
     {
-        /// <summary>Gets the command identifier.
-        /// </summary>
-        Guid Id { get; }
     }
 }

--- a/src/Vigil.Domain/Messaging/IEvent.cs
+++ b/src/Vigil.Domain/Messaging/IEvent.cs
@@ -2,9 +2,8 @@
 
 namespace Vigil.Domain.Messaging
 {
-    public interface IEvent
+    public interface IEvent : IKeyIdentity
     {
-        Guid Id { get; }
         Guid SourceId { get; }
     }
 }

--- a/src/Vigil.Patrons/PatronCommandHandler.cs
+++ b/src/Vigil.Patrons/PatronCommandHandler.cs
@@ -5,7 +5,7 @@ using Vigil.Patrons.Events;
 
 namespace Vigil.Patrons
 {
-    public class PatronCommandHandler : ICommandHandler<CreatePatronCommand>
+    public class PatronCommandHandler : ICommandHandler<CreatePatronCommand>, ICommandHandler<UpdatePatronCommand>
     {
         private readonly IEventBus eventBus;
         private readonly ICommandRepository repo;

--- a/test/Vigil.Patrons.Tests/PatronCommandHandlerTest.cs
+++ b/test/Vigil.Patrons.Tests/PatronCommandHandlerTest.cs
@@ -35,7 +35,7 @@ namespace Vigil.Patrons
             var repo = new Mock<ICommandRepository>();
             repo.Setup(re => re.Save(It.Is<CreatePatronCommand>(cpc => cpc.Id == command.Id))).Verifiable();
 
-            PatronCommandHandler handler = new PatronCommandHandler(eventBus.Object, repo.Object);
+            ICommandHandler<CreatePatronCommand> handler = new PatronCommandHandler(eventBus.Object, repo.Object);
             handler.Handle(command);
 
             Assert.NotEqual(Guid.Empty, command.Id);
@@ -66,7 +66,7 @@ namespace Vigil.Patrons
             var repo = new Mock<ICommandRepository>();
             repo.Setup(re => re.Save(It.Is<UpdatePatronCommand>(cpc => cpc.Id == command.Id))).Verifiable();
 
-            PatronCommandHandler handler = new PatronCommandHandler(eventBus.Object, repo.Object);
+            ICommandHandler<UpdatePatronCommand> handler = new PatronCommandHandler(eventBus.Object, repo.Object);
             handler.Handle(command);
 
             Assert.NotEqual(Guid.Empty, command.Id);


### PR DESCRIPTION
…the interface, thus ensuring that the command handler can handle the particular command under test.

Move the 'id' property from the ICommand and IEvent interfaces to be inherited from the IKeyIdentity interface.